### PR TITLE
Updated to Swift 5.1 and fixed deprecations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 
 /**
  *  ShellOut

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -376,7 +376,12 @@ extension ShellOutError: LocalizedError {
 
 private extension Process {
     @discardableResult func launchBash(with command: String, outputHandle: FileHandle? = nil, errorHandle: FileHandle? = nil) throws -> String {
-        launchPath = "/bin/bash"
+
+        if #available(OSX 10.13, *) {
+            executableURL = URL(fileURLWithPath: "/bin/bash")
+        } else {
+            launchPath = "/bin/bash"
+        }
         arguments = ["-c", command]
 
         // Because FileHandle's readabilityHandler might be called from a
@@ -394,7 +399,6 @@ private extension Process {
         let errorPipe = Pipe()
         standardError = errorPipe
 
-        #if !os(Linux)
         outputPipe.fileHandleForReading.readabilityHandler = { handler in
             let data = handler.availableData
             outputQueue.async {
@@ -410,16 +414,12 @@ private extension Process {
                 errorHandle?.write(data)
             }
         }
-        #endif
 
-        launch()
-
-        #if os(Linux)
-        outputQueue.sync {
-            outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-            errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if #available(OSX 10.13, *) {
+            try run()
+        } else {
+            launch()
         }
-        #endif
 
         waitUntilExit()
 
@@ -431,10 +431,8 @@ private extension Process {
             handle.closeFile()
         }
 
-        #if !os(Linux)
         outputPipe.fileHandleForReading.readabilityHandler = nil
         errorPipe.fileHandleForReading.readabilityHandler = nil
-        #endif
 
         // Block until all writes have occurred to outputData and errorData,
         // and then read the data back out.

--- a/Tests/ShellOutTests/ShellOutTests+Linux.swift
+++ b/Tests/ShellOutTests/ShellOutTests+Linux.swift
@@ -14,9 +14,14 @@ extension ShellOutTests {
         ("testWithArguments", testWithArguments),
         ("testWithInlineArguments", testWithInlineArguments),
         ("testSingleCommandAtPath", testSingleCommandAtPath),
+        ("testSingleCommandAtPathContainingSpace", testSingleCommandAtPathContainingSpace),
+        ("testSingleCommandAtPathContainingTilde", testSingleCommandAtPathContainingTilde),
         ("testSeriesOfCommands", testSeriesOfCommands),
         ("testSeriesOfCommandsAtPath", testSeriesOfCommandsAtPath),
         ("testThrowingError", testThrowingError),
+        ("testErrorDescription", testErrorDescription),
+        ("testCapturingOutputWithHandle", testCapturingOutputWithHandle),
+        ("testCapturingErrorWithHandle", testCapturingErrorWithHandle),
         ("testGitCommands", testGitCommands),
         ("testSwiftPackageManagerCommands", testSwiftPackageManagerCommands)
     ]

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -41,8 +41,8 @@ class ShellOutTests: XCTestCase {
     }
 
     func testSingleCommandAtPathContainingTilde() throws {
-        let homeContents = try shellOut(to: "ls", at: "~")
-        XCTAssertFalse(homeContents.isEmpty)
+        let homeFolders = try shellOut(to: "ls", at: "~/..")
+        XCTAssertFalse(homeFolders.isEmpty)
     }
 
     func testSeriesOfCommands() throws {


### PR DESCRIPTION
Remove "#if os" checks, since `readabilityHandler` was implemented on Linux in Swift 5.1.
Added "#if available" checks to use `executableURL` and `run()` instead of `launchPath` and `launch()` on macOS 10.13+ and Linux.
Added missing tests to `allTests` so they run on Linux.
Changed `testSingleCommandAtPathContainingTilde()` as it formerly failed with an empty home directory (common on Linux and Docker images).